### PR TITLE
Add vpc module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.terraform
+.DS_Store
+*.tfstate
+terraform.tfstate.backup
+*_key
+.terraform.lock.hcl

--- a/network/dev/backend.tf
+++ b/network/dev/backend.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+  region = "ap-northeast-1"
+  default_tags {
+    tags = {
+      createdBy = "terraform"
+      service   = "sandbox"
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket = "kd-tf-sandbox"
+    key    = "network/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.13.0"
+    }
+  }
+}

--- a/network/dev/main.tf
+++ b/network/dev/main.tf
@@ -1,0 +1,11 @@
+locals {
+  env = "dev"
+}
+
+module "vpc" {
+  source               = "../modules/vpc"
+  name                 = "sandbox"
+  env                  = local.env
+  cidr                 = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}

--- a/network/modules/vpc/variables.tf
+++ b/network/modules/vpc/variables.tf
@@ -1,0 +1,40 @@
+variable "env" {
+  description = "Environment resouce name"
+  type        = string
+  default     = ""
+}
+variable "name" {
+  description = "Name to be used on all the resources as identifier"
+  type        = string
+  default     = ""
+}
+
+variable "cidr" {
+  description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_ipv6" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_tags" {
+  description = "Additional tags for the VPC"
+  type        = map(string)
+  default     = {}
+}

--- a/network/modules/vpc/vpc.tf
+++ b/network/modules/vpc/vpc.tf
@@ -1,0 +1,15 @@
+################################################################################
+# VPC
+################################################################################
+
+resource "aws_vpc" "vpc" {
+  cidr_block                       = var.cidr
+  enable_dns_hostnames             = var.enable_dns_hostnames
+  enable_dns_support               = var.enable_dns_support
+  assign_generated_ipv6_cidr_block = var.enable_ipv6
+
+  tags = merge(
+    { "Name" = "${var.name}-${var.env}-vpc" },
+    var.vpc_tags,
+  )
+}


### PR DESCRIPTION
```
  # module.vpc.aws_vpc.vpc will be created
  + resource "aws_vpc" "vpc" {
      + arn                                  = (known after apply)
      + assign_generated_ipv6_cidr_block     = false
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = true
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Name" = "sandbox-dev-vpc"
        }
      + tags_all                             = {
          + "Name"      = "sandbox-dev-vpc"
          + "createdBy" = "terraform"
          + "service"   = "sandbox"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```